### PR TITLE
fix proxy image tagging

### DIFF
--- a/deployments/liqo/templates/liqo-proxy-deployment.yaml
+++ b/deployments/liqo/templates/liqo-proxy-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       securityContext:
         {{- include "liqo.podSecurityContext" . | nindent 8 }}
       containers:
-        - image: {{ .Values.proxy.imageName }}{{ include "liqo.suffix" $proxyConfig }}:{{ include "liqo.version" $proxyConfig }}
+        - image: {{ .Values.proxy.imageName }}{{ include "liqo.suffix" $proxyConfig }}:{{ .Values.proxy.imageTag | default (include "liqo.version" $proxyConfig) }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           name: {{ $proxyConfig.name }}
           securityContext:

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -494,6 +494,7 @@ proxy:
       requests: {}
   # -- Image repository for the proxy pod.
   imageName: "ghcr.io/liqotech/proxy"
+  imageTag: ""
   service:
     type: "ClusterIP"
     annotations: {}


### PR DESCRIPTION
# Description

fixes this problem:

Failed to apply default image tag "envoyproxy/envoy:v1.21.0:v0.9.4": couldn't parse image reference "envoyproxy/envoy:v1.21.0:v0.9.4": invalid reference format

Then to change the image in the values this is the correct value:
```
proxy:
  imageName: envoyproxy/envoy
  imageTag: v1.21.0
```

# How Has This Been Tested?

I tried to deploy on my 2 clusters